### PR TITLE
Draft 2

### DIFF
--- a/guile/examples.scm
+++ b/guile/examples.scm
@@ -1,0 +1,342 @@
+;; First, let's make sure that Guile will look for the
+;; SRFI-201 module in the current directory:
+
+(set! %load-path `("." . ,%load-path))
+
+;; Now load the module:
+
+(use-modules (srfi srfi-201))
+
+;; Before showing the capabilities of SRFI-201,
+;; we're going to build a little unit test framework
+;; for ourselves. The main interface to the framework
+;; will be the "e.g." form, whose main use is going to
+;; be:
+
+;; (e.g. <expression> ===> <value>)
+
+;; which checks whether <expression> evaluates to <value>,
+;; and reports an error if that's not the case.
+
+;; A more primitive use of the form is
+
+;; (e.g. <expression>)
+
+;; which passes if <expression> evaluates to non-#f value.
+;; The former usage could therefore be defined in the terms
+;; of the latter as:
+
+;; (e.g. <expression> ===> <value>)
+;; === (e.g. (equal? <expression> '<value>))
+
+;; Moreover, since Scheme expressions can in general have
+;; more (or less) than one value, we allow the usages:
+
+;; (e.g. <expression> ===> <values> ...)
+
+;; where <values> ... is a sequence of zero or more
+;; literals.
+
+;; Our examples, however, are also going to include
+;; expressions that are not valid syntax, or ones such
+;; that their execution causes runtime errors (similar
+;; to arity mismatch in procedure application)
+
+;; Therefore, expressions causing runtime errors
+;; will be expressed as
+
+;; (e.g. <expression> ===>! runtime-error)
+
+;; and expressions causing expansion-time errors
+;; will be marked as
+
+;; (e.g. <expression> ===>! syntax-error)
+
+;; Note that it is an error for such expressions not
+;; to raise an error!
+
+;; There's also another class of expressions that we'd like
+;; to be able to express, namely - syntactic forms whose
+;; behavior is unspecified, and such that may or may not
+;; raise an error, depending on a specific implementation.
+;; We need to be prepared for handling errors from them,
+;; but it's OK if they don't raise any errors.
+
+;; We're going to mark these expressions using the ===>?!
+;; arrow.
+
+(define-syntax e.g.
+  (syntax-rules (===>
+		 ===>!
+		 ===>?!
+		 syntax-error
+		 runtime-error)
+    ;; let's start with the simplest case: a test which
+    ;; fails when expression evaluates to #f
+    ((e.g. <example>)
+     (or <example>
+	 (error '<example>)))
+
+    ;; and here's a variant with an expected result
+    ((e.g. <expression> ===> <values> ...)
+     (call-with-values (lambda () <expression>)
+       (lambda results
+	 (if (equal? results '(<values> ...))
+	     (apply values results)
+	     (error '(<expression> ===> <values> ...)
+		    results)))))
+
+    ;; in case of runtime errors, we need to use Guile's
+    ;; mechanism for recovering from errors:
+    ((e.g. <expression> ===>! runtime-error)
+     (let ((failure (catch #t
+		      ;; if <expression> succeeds, we return #f
+		      ;; so that the handler will know that
+		      ;; no error has occurred, and will be
+		      ;; able to report that as an error
+		      (lambda () <expression> #f)
+		      ;; otherwise if an error is raised,
+		      ;; we return the information about
+		      ;; the error (it is a list of arguments,
+		      ;; so if certainly won't be #f)
+		      (lambda reason reason))))
+       (or failure
+	   (error '<expression> 'succeeded))))
+
+    ;; the case of detecting syntax errors is slightly more
+    ;; complicated: if we tried to include a piece of
+    ;; invalid syntax as an expression, we would obtain
+    ;; syntactically invalid program. So instead we quote
+    ;; the expression and try to evaluate it, expecting
+    ;; an error
+    ((e.g. <expression> ===>! syntax-error)
+     (let ((failure (catch #t
+		      (lambda ()
+			(eval '<expression>
+			      (current-module))
+			#f)
+		      (lambda reason reason))))
+       (or failure
+	   (error '<expression> 'succeeded))))
+
+    ;; In the case of "unspecified behavior", we only
+    ;; need to protect ourselves from the possibility
+    ;; of <expression> causing either runtime or expansion
+    ;; time error, but it's ok if none of such errors
+    ;; occurs
+    ((e.g. <expression> ===>?! reason)
+     (catch #t
+       (lambda ()
+	 (eval '<expression> (current-module)))
+       (lambda reason reason)))))
+
+;; Now that we have built a "metalanguage" for talking about
+;; the values/behaviors of expressions, we can move on to
+;; specifying the extensions to the core macros.
+
+;; The ones presented here are built on top of Alex Shinn's
+;; match macro, which is shipped with Guile as the
+;; (ice-9 match) module. It is important to emphasize
+;; that SRFI-201 is intended to work with whatever pattern
+;; matcher is provided for a given Scheme implementation.
+
+;; SRFI-201's let form allows to handle
+;; multiple values and perform desttucturing
+;; bindings
+(e.g.
+ (let ((`(,x) `(,y) (values '(1) '(2))))
+   (list x y))
+ ===> (1 2))
+
+;; The additional values, if present, are ignored
+(e.g.
+ (let ((x y (values 1 2 3)))
+   (list x y))
+ ===> (1 2))
+
+;; If there's one multiple-value binding in a let
+;; form, it must be the only binding in that form.
+
+;; While it would be possible to implement this,
+;; preserving the semantics of the 'let' form,
+;; it would require capturing the results into
+;; heap-allocated lists, which might be inefficient.
+;;
+;; For this reason, we encourage to use multiple
+;; multiple value bindings only inside of a let* form,
+;; which allows to implement this facility more
+;; efficiently and naturally.
+
+(e.g.
+ (let ((x y (values 1 2))
+       (z 3))
+   (list x y z)) ===>?! syntax-error)
+
+(e.g.
+ (let (((values x y) '(values 1 2))
+       (z 3))
+   (list x y z)) ===>?! syntax-error)
+
+;; The 'values' keyword is treated specially
+;; in the context of binding:
+(e.g.
+ (let (((values x y) (values 1 2)))
+   (list x y))
+ ===> (1 2))
+
+;; This no longer allows us to ignore unused
+;; values
+(e.g.
+ (let (((values x y) (values 1 2 3)))
+   (list x y))
+ ===>! runtime-error)
+
+;; But, the remaining values can be captured
+;; in a list:
+(e.g.
+ (let (((values x y . z) (values 1 2 3)))
+   (values
+    (list x y)
+    z))
+ ===> (1 2) (3))
+
+;; The 'named-let' is of course supported 
+(e.g.
+ (let loop ((x 0))
+   (if (>= x 10)
+       x
+       (loop (+ x 1))))
+ ===> 10)
+
+;; and it is also capable of destructuring
+(e.g.
+ (let loop ((`(,x) '(0)))
+   (if (>= x 10)
+       x
+       (loop `(,(+ x 1)))))
+ ===> 10)
+
+;; There is an option to use a named-let with multiple
+;; values:
+
+(e.g.
+ (let loop ((`(,x) y (values '(1) 2)))
+   (if (>= (+ x y) 10)
+       (values x y)
+       (loop `(,(+ x 1)) (+ y 1))))
+ ===> 5 6)
+
+;; It also works with the 'values' keyword:
+
+(e.g.
+ (let loop (((values x `(,y)) (values 1 '(2))))
+   (if (>= (+ x y) 10)
+       (values x y)
+       (loop (+ x 1) `(,(+ y 1)))))
+ ===> 5 6)
+
+;; But like with unnamed let, if there's a multiple value
+;; binding, it precludes all other bindings from the form:
+
+(e.g.
+ (let loop ((a b (values 1 2))
+	    (c 3))
+   'whatever) ===>! syntax-error)
+
+;; and the 'values' keyword doesn't change that: 
+
+(e.g.
+ (let loop (((values a b) (values 1 2))
+	    (c 3))
+   'whatever) ===>! syntax-error)
+
+;; The let* form inherits most of the let form's
+;; capabilities:
+(e.g.
+ (let* ((`(,x) y (values '(1) 2 3))
+	(z `(,w) (values 4 '(5))))
+   (list x y z w))
+ ===> (1 2 4 5))
+
+;; including the support for the "values"
+;; keyword on left positions
+
+(e.g.
+ (let* (((values `(,x) y . _) (values '(1) 2 3))
+	((values z `(,w)) (values 4 '(5))))
+   (list x y z w))
+ ===> (1 2 4 5))
+
+
+;; The lambda keyword allows to destructure arguments
+
+(e.g.
+ (map (lambda (`(,l . ,r))
+	(+ l r))
+      '((1 . 2) (3 . 4) (5 . 6)))
+ ===> (3 7 11))
+
+;; But body-less lambdas can be used for filtering patterns:
+
+(e.g.
+ (filter (lambda (`(,_ ,_ ,_)))
+	 '((1 2) (3 4 5) (6 7) (8 9 0)))
+ ===> ((3 4 5) (8 9 0)))
+
+;; This also allows to express a procedure that returns #t
+;; for any argument as
+
+(e.g.
+ (lambda _))
+
+;; and I think it's beautiful.
+
+;; It is an error to apply a lambda to an object that cannot
+;; be properly desctructured (just like it is an error
+;; to apply a lambda to a larger or smaller number of arguments
+;; than it supports, i.e. arity mismatch error)
+
+(e.g.
+ ((lambda (`(,x . ,y)) 'whatever) '()) ===>! runtime-error)
+
+;; The 'define' keyword supports currying, and it
+;; desugars to destructuring lambdas:
+
+(e.g.
+ (let ()
+   (define ((f `(,a ,b)) `(,c ,d))
+     `(,a ,b ,c ,d))
+   ((f '(1 2)) '(3 4)))
+ ===> (1 2 3 4))
+
+;; Body-less curried definitions only test for validity
+;; of patterns, so they don't throw 'invalid match' errors,
+;; but return #t on successful 
+
+(e.g.
+ (let ()
+   (define ((f `(,a ,b)) `(,c ,d)))
+   (and ((f '(1 2)) '(3 4))
+	(not ((f 5) '(6 7))))))
+
+;; The "or" form ought to perform short-circuiting
+;; while still supporting multiple values. Only the
+;; first value can account to short-circuiting:
+
+(e.g.
+ (or (values #f 5)
+     (values 6 7 8))
+ ===> 6 7 8)
+
+(e.g.
+ (or (values #t 5)
+     (values 6 7 8))
+ ===> #t 5)
+
+;; As in thw context of if's condition, any value other than
+;; #f is considered true:
+
+(e.g.
+ (or (values 4 5)
+     (values 6 7 8))
+ ===> 4 5)

--- a/guile/examples.scm
+++ b/guile/examples.scm
@@ -1,9 +1,6 @@
-;; First, let's make sure that Guile will look for the
-;; SRFI-201 module in the current directory:
-
-(set! %load-path `("." . ,%load-path))
-
-;; Now load the module:
+#!/usr/bin/guile \
+-L . -s
+!#
 
 (use-modules (srfi srfi-201))
 

--- a/guile/srfi/srfi-201.scm
+++ b/guile/srfi/srfi-201.scm
@@ -1,0 +1,218 @@
+(define-module (srfi srfi-201)
+  #:use-module (srfi srfi-1)
+  #:use-module (ice-9 match)
+  #:replace ((cdefine . define)
+	     (mlambda . lambda)
+	     (named-match-let-values . let)
+	     (or/values . or)
+	     (match-let*-values . let*)))
+
+(define-syntax mlambda
+  (lambda (stx)
+    (syntax-case stx ()
+      ;; lambda with no body is treated as a pattern predicate,
+      ;; returning #t if the argument matches, and #f otherwise
+      ((_ args)
+       #'(lambda args*
+	   (match args*
+	     (args #t)
+	     (_ #f))))
+
+      ;; in case of patterns consisting entitely
+      ;; of identifiers, we desugar to the core lambda
+      ((_ (first-arg ... last-arg . rest-args) . body)
+       (and (every identifier? #'(first-arg ... last-arg))
+	    (or (identifier? #'rest-args) (null? #'rest-args)))
+       #'(lambda (first-arg ... last-arg . rest-args) . body))
+
+      ((_ arg body ...)
+       (or (identifier? #'arg) (null? #'arg))
+       #'(lambda arg body ...))
+
+      ((_ pattern body ...)
+       #'(lambda args
+	   (match args
+	     (pattern body ...) 
+	     (_ (error
+		 `((mlambda pattern body ...) ,args))))))
+      )))
+
+(define-syntax cdefine
+  (syntax-rules ()
+    ;; for consistency with bodyless lambdas,
+    ;; bodyless curried definitions only pattern-match
+    ;; on their arguments, and return #t if all matches
+    ;; succeed, or #f if some of the matches fail
+    ((_ (prototype . args))
+     (cdefine-bodyless (prototype . args) #t))
+
+    ((_ ((head . tail) . args) body ...)
+     (cdefine (head . tail)
+	      (mlambda args body ...)))
+    ((_ (function . args) body ...)
+     (define function
+       (mlambda args body ...)))
+    ((_ . rest)
+     (define . rest))
+    ))
+
+(define-syntax cdefine-bodyless
+  (syntax-rules ()
+   ((_ (function . pattern) result . args)
+    (cdefine-bodyless function
+		      (match arg
+			(pattern result)
+			(_ #f))
+		      arg . args))
+   
+   ((_ name result args ... arg)
+    (cdefine-bodyless name (lambda arg result) args ...))
+
+   ((_ name value)
+    (define name value))
+   ))
+
+(define-syntax match-let/error
+  (syntax-rules ()
+    ((_ ((structure expression) ...)
+	body + ...)
+     ((lambda args
+	(match args
+	  ((structure ...) body + ...)
+	  (_ (error 'match-let/error
+		    (current-source-location) 
+		    '((structure expression) ...)
+		    expression ...))))
+      expression ...))))
+
+(define-syntax named-match-let-values
+  (lambda (stx)
+    (syntax-case stx (values)
+      ((_ ((identifier expression) ...) 
+	  body + ...)
+       (every identifier? #'(identifier ...))
+       ;; optimization: plain "let" form
+       #'(let ((identifier expression) ...)
+	   body + ...))
+
+      ((_ name ((identifier expression) ...) 
+	  body + ...)
+       (and (identifier? #'name)
+	    (every identifier? #'(identifier ...)))
+       ;; optimization: regular named-let
+       #'(let name ((identifier expression) ...)
+	   body + ...))
+
+      ((_ name (((values . structure) expression))
+	  body + ...)
+       (identifier? #'name)
+       #'(letrec ((name (mlambda structure body + ...)))
+	   (call-with-values (lambda () expression) name)))
+
+      ((_ (((values . structure) expression)) body + ...)
+       #'(call-with-values (lambda () expression)
+	   (mlambda structure body + ...)))
+
+      ((_ name ((structure expression) ...)
+	  body + ...)
+       (and (identifier? #'name)
+	    (any (lambda (pattern)
+		   (and (pair? pattern)
+			(eq? (car pattern) 'values)))
+		 (syntax->datum #'(structure ...))))
+       #'(syntax-error "let can only handle one binding \
+in the presence of a multiple-value binding"))
+      
+      ((_ name ((structure expression) ...)
+	  body + ...)
+       (identifier? #'name)
+       #'(letrec ((name (mlambda (structure ...) body + ...)))
+	   (name expression ...)))
+
+      ((_ ((structure expression) ...)
+	  body + ...)
+       (any (lambda (pattern)
+	      (and (pair? pattern)
+		   (eq? (car pattern) 'values)))
+	    (syntax->datum #'(structure ...)))
+       #'(syntax-error "let can only handle one binding \
+in the presence of a multiple-value binding"))
+      
+      ((_ ((structure expression) ...)
+	  body + ...)
+       #'(match-let/error ((structure expression) ...) 
+			  body + ...))
+
+      ((_ ((structure structures ... expression)) body + ...)
+       #'(call-with-values (lambda () expression)
+	   (mlambda (structure structures ... . _)
+		    body + ...)))
+
+      ((_ name ((structure structures ... expression))
+		body + ...)
+       (identifier? #'name)
+       #'(letrec ((name (mlambda (structure structures ...)
+			     body + ...)))
+	   (call-with-values (lambda () expression) name)))
+
+      ;; it should generally be discouraged to use the plain
+      ;; let with multiple values, because there's no natural
+      ;; way to implement that when there's more than one
+      ;; (multiple-value) binding,
+      ;; but it could be added for completeness
+#|
+      ((_ ((structure structures ... expression) ...)
+	  body + ...)
+       #'(match-let/error (((structure structures ... . _) 
+			    (list<-values expression)) ...)
+			  body + ...))
+      
+      ((_ name ((structure structures ... expression) ...)
+	  body + ...)
+       (identifier? #'name)
+       #'(letrec ((loop
+		   (lambda args
+		     (match args
+		       (((structure structures ... . _) ...)
+			(let-syntax ((name
+				      (syntax-rules ()
+					((_ args (... ...))
+					 (loop (list<-values
+						args)
+					       (... ...))))))
+			  body + ...))
+		     (_ (error 'named-match-let-values 
+			       (current-source-location)
+			       'name)))))
+		  (loop (list<-values expression) ...)))
+|#
+      )))
+
+(define-syntax or/values
+  (syntax-rules ()
+    ((_)
+     #false)
+    
+    ((or/values final)
+     final)
+    
+    ((or/values first . rest)
+     (call-with-values (lambda () first)
+       (lambda result
+	 (if (and (pair? result) (car result))
+	     (apply values result)
+	     (or/values . rest)))))))
+
+(define-syntax match-let*-values
+  (lambda (stx)
+    (syntax-case stx ()
+      ((_ ((identifier expression) ...) body + ...)
+       (every identifier? #'(identifier ...))
+       ;; optimization/base case: regular let*
+       #'(let* ((identifier expression) ...)
+	   body + ...))
+      ((_ (binding . bindings) body + ...)
+       #'(named-match-let-values (binding)
+				 (match-let*-values
+				  bindings
+				  body + ...))))))

--- a/racket/examples.rkt
+++ b/racket/examples.rkt
@@ -1,0 +1,344 @@
+#!/usr/bin/racket
+#lang racket
+
+(require "srfi/201.rkt")
+
+;; Before showing the capabilities of SRFI-201,
+;; we're going to build a little unit test framework
+;; for ourselves. The main interface to the framework
+;; will be the "e.g." form, whose main use is going to
+;; be:
+
+;; (e.g. <expression> ===> <value>)
+
+;; which checks whether <expression> evaluates to <value>,
+;; and reports an error if that's not the case.
+
+;; A more primitive use of the form is
+
+;; (e.g. <expression>)
+
+;; which passes if <expression> evaluates to non-#f value.
+;; The former usage could therefore be defined in the
+;; terms of the latter as:
+
+;; (e.g. <expression> ===> <value>)
+;; === (e.g. (equal? <expression> '<value>))
+
+;; Moreover, since Scheme expressions can in general have
+;; more (or less) than one value, we allow the usages:
+
+;; (e.g. <expression> ===> <values> ...)
+
+;; where <values> ... is a sequence of zero or more
+;; literals.
+
+;; Our examples, however, are also going to include
+;; expressions that are not valid syntax, or ones such
+;; that their execution causes runtime errors (similar
+;; to arity mismatch in procedure application)
+
+;; Therefore, expressions causing runtime errors
+;; will be expressed as
+
+;; (e.g. <expression> ===>! runtime-error)
+
+;; and expressions causing expansion-time errors
+;; will be marked as
+
+;; (e.g. <expression> ===>! syntax-error)
+
+;; Note that it is an error for such expressions not
+;; to raise an error!
+
+;; There's also another class of expressions that we want
+;; to be able to express, namely - syntactic forms whose
+;; behavior is unspecified, and such that may or may not
+;; raise an error, depending on a specific implementation.
+;; We need to be prepared for handling errors from them,
+;; but it's OK if they don't raise any errors.
+
+;; We're going to mark these expressions using the ===>?!
+;; arrow.
+
+(define-syntax e.g.
+  (syntax-rules (===>
+		 ===>!
+		 ===>?!
+		 syntax-error
+		 runtime-error)
+    ;; let's start with the simplest case: a test which
+    ;; fails when expression evaluates to #f
+    ((e.g. <example>)
+     (or <example>
+	 (error "false example" '<example>)))
+
+    ;; and here's a variant with an expected result
+    ((e.g. <expression> ===> <values> ...)
+     (call-with-values (lambda () <expression>)
+       (lambda results
+	 (if (equal? results '(<values> ...))
+	     (apply values results)
+	     (error "false example"
+		    '<expression>
+		    `(expected ,<values> ...
+			       got . ,results))))))
+
+    ;; in case of runtime errors, we need to use Guile's
+    ;; mechanism for recovering from errors:
+    ((e.g. <expression> ===>! runtime-error)
+     ;; if an error is raised,
+     ;; we return the information about
+     ;; the error
+     (let ((failure (with-handlers ((exn:fail? identity))
+		      ;; if <expression> succeeds,
+		      ;; we return #f so that the handler
+		      ;; will know that  no error has
+		      ;; occurred, and will be
+		      ;; able to report that as an error
+		      <expression>
+		      #f)))
+       (or failure
+	   (error "unexpected success" '<expression>))))
+
+    ;; the case of detecting syntax errors is a bit more
+    ;; complicated: if we tried to include a piece of
+    ;; invalid syntax as an expression, we would obtain
+    ;; syntactically invalid program. So instead we quote
+    ;; the expression and try to evaluate it, expecting
+    ;; an error    
+    ((e.g. <expression> ===>! syntax-error)
+     (let ((failure (with-handlers ((exn:fail? identity))
+		      (eval '<expression>)
+		      #f)))
+       (or failure
+	   (error "unexpected success" '<expression>))))
+
+    ;; In the case of "unspecified behavior", we only
+    ;; need to protect ourselves from the possibility
+    ;; of <expression> causing either runtime or expansion
+    ;; time error, but it's ok if none of such errors
+    ;; occurs
+    ((e.g. <expression> ===>?! reason)
+     (with-handlers ((exn:fail? identity))
+       (eval '<expression>)))
+    ))
+
+;; Now that we have built a "metalanguage" for talking about
+;; the values/behaviors of expressions, we can move on to
+;; specifying the extensions to the core macros.
+
+;; The ones presented here are built on top of Alex Shinns
+;; match macro, which is shipped with Guile as the
+;; (ice-9 match) module. It is important to emphasize
+;; that SRFI-201 is intended to work with whatever pattern
+;; matcher is provided for a given Scheme implementation.
+
+;; SRFI-201's let form allows to handle
+;; multiple values and perform desttucturing
+;; bindings
+(e.g.
+ (let ((`(,x) `(,y) (values '(1) '(2))))
+   (list x y))
+ ===> (1 2))
+
+
+;; The additional values, if present, are ignored
+(e.g.
+ (let ((x y (values 1 2 3)))
+   (list x y))
+ ===> (1 2))
+
+;; If there's one multiple-value binding in a let
+;; form, it must be the only binding in that form.
+
+;; While it would be possible to implement this,
+;; preserving the semantics of the 'let' form,
+;; it would require capturing the results into
+;; heap-allocated lists, which might be inefficient.
+;;
+;; For this reason, we encourage to use multiple
+;; multiple value bindings only inside of a let* form,
+;; which allows to implement this facility more
+;; efficiently and naturally.
+
+(e.g.
+ (let ((x y (values 1 2))
+       (z 3))
+   (list x y z)) ===>?! syntax-error)
+
+(e.g.
+ (let (((values x y) '(values 1 2))
+       (z 3))
+   (list x y z)) ===>?! syntax-error)
+
+;; The 'values' keyword is treated specially
+;; in the context of binding:
+(e.g.
+ (let (((values x y) (values 1 2)))
+   (list x y))
+ ===> (1 2))
+
+;; This no longer allows us to ignore unused
+;; values
+(e.g.
+ (let (((values x y) (values 1 2 3)))
+   (list x y))
+ ===>! runtime-error)
+
+;; But, the remaining values can be captured
+;; in a list:
+(e.g.
+ (let (((values x y . z) (values 1 2 3)))
+   (values
+    (list x y)
+    z))
+ ===> (1 2) (3))
+
+;; The 'named-let' is of course supported 
+(e.g.
+ (let loop ((x 0))
+   (if (>= x 10)
+       x
+       (loop (+ x 1))))
+ ===> 10)
+
+;; and it is also capable of destructuring
+(e.g.
+ (let loop ((`(,x) '(0)))
+   (if (>= x 10)
+       x
+       (loop `(,(+ x 1)))))
+ ===> 10)
+
+;; There is an option to use a named-let with multiple
+;; values:
+
+(e.g.
+ (let loop ((`(,x) y (values '(1) 2)))
+   (if (>= (+ x y) 10)
+       (values x y)
+       (loop `(,(+ x 1)) (+ y 1))))
+ ===> 5 6)
+
+;; It also works with the 'values' keyword:
+
+(e.g.
+ (let loop (((values x `(,y)) (values 1 '(2))))
+   (if (>= (+ x y) 10)
+       (values x y)
+       (loop (+ x 1) `(,(+ y 1)))))
+ ===> 5 6)
+
+;; But like with unnamed let, if there's a multiple value
+;; binding, it precludes all other bindings from the form:
+
+(e.g.
+ (let loop ((a b (values 1 2))
+	    (c 3))
+   'whatever) ===>! syntax-error)
+
+;; and the 'values' keyword doesn't change that: 
+
+(e.g.
+ (let loop (((values a b) (values 1 2))
+	    (c 3))
+   'whatever) ===>! syntax-error)
+
+
+;; The let* form inherits most of the let form's
+;; capabilities:
+(e.g.
+ (let* ((`(,x) y (values '(1) 2 3))
+	(z `(,w) (values 4 '(5))))
+   (list x y z w))
+ ===> (1 2 4 5))
+
+;; including the support for the "values"
+;; keyword on left positions
+
+(e.g.
+ (let* (((values `(,x) y . _) (values '(1) 2 3))
+	((values z `(,w)) (values 4 '(5))))
+   (list x y z w))
+ ===> (1 2 4 5))
+
+
+;; The lambda keyword allows to destructure arguments
+
+(e.g.
+ (map (lambda (`(,l . ,r))
+	(+ l r))
+      '((1 . 2) (3 . 4) (5 . 6)))
+ ===> (3 7 11))
+
+;; But body-less lambdas can be used e.g. for
+;; filtering based on patterns:
+
+(e.g.
+ (filter (lambda (`(,_ ,_ ,_)))
+	 '((1 2) (3 4 5) (6 7) (8 9 0)))
+ ===> ((3 4 5) (8 9 0)))
+
+;; This also allows to express a procedure that returns #t
+;; for any argument as
+
+(e.g.
+ (lambda _))
+
+;; and I think it's beautiful.
+
+(e.g.
+ (and ((lambda _))
+      (andmap (lambda _) (list "1" 5 '(x y) '() #f))
+      ((lambda _) "1" 5 '(x y) '())))
+
+;; It is an error to apply a lambda to an object that cannot
+;; be properly desctructured (just like it is an error
+;; to apply a lambda to a larger or smaller number of arguments
+;; than it supports, i.e. arity mismatch error)
+
+(e.g.
+ ((lambda (`(,x . ,y)) 'whatever) '()) ===>! runtime-error)
+
+;; The 'define' keyword supports currying, and it
+;; desugars to destructuring lambdas:
+
+(e.g.
+ (let ()
+   (define ((f `(,a ,b)) `(,c ,d))
+     `(,a ,b ,c ,d))
+   ((f '(1 2)) '(3 4)))
+ ===> (1 2 3 4))
+
+;; Body-less curried definitions only test for validity
+;; of patterns, so they don't throw 'invalid match' 
+;; errors, but return #t on successful 
+
+(e.g.
+ (let ()
+   (define ((f `(,a ,b)) `(,c ,d)))
+   (and ((f '(1 2)) '(3 4))
+	(not ((f 5) '(6 7))))))
+
+;; The "or" form ought to perform short-circuiting
+;; while still supporting multiple values. Only the
+;; first value can account to short-circuiting:
+
+(e.g.
+ (or (values #f 5)
+     (values 6 7 8))
+ ===> 6 7 8)
+
+(e.g.
+ (or (values #t 5)
+     (values 6 7 8))
+ ===> #t 5)
+
+;; As in the context of if's condition, any value
+;; other than #f is considered true:
+
+(e.g.
+ (or (values 4 5)
+     (values 6 7 8))
+ ===> 4 5)

--- a/racket/srfi/201.rkt
+++ b/racket/srfi/201.rkt
@@ -1,0 +1,249 @@
+#lang racket
+(require racket/match)
+
+(define-for-syntax (every pred stx)
+  (andmap pred (syntax->list stx)))
+
+(define-for-syntax (any pred stx)
+  (ormap pred (syntax->list stx)))
+
+(define-for-syntax (empty? stx)
+  (null? (syntax->list stx)))
+
+(define-for-syntax (racket-argument? x)
+  "racket argument is either an identifier, a keyword or a [name value] pair"
+  (or (identifier? x)
+      (keyword? (syntax->datum x))
+      (let ((list (syntax->list x)))
+	(and (list? list)
+	     (= (length list) 2)
+	     (let ((name (syntax->datum (car list))))
+	       (and (not (eq? name 'quote))
+		    (not (eq? name 'quasiquote))))))))
+
+(provide #%module-begin #%app #%datum syntax-rules
+         (rename-out [cdefine define]
+                     [mlambda lambda]
+                     [named-match-let-values let]
+                     [or/values or]
+                     [match-let*-values let*]
+		     ))
+
+(define-syntax list-pattern
+  ;; convert Scheme-style arguments (proper or improper
+  ;; lists) into Racket matcher's pattern (either
+  ;; (list args ...) or (list-rest args ... tail))
+  (syntax-rules ()
+    ((list-pattern final failure (first second . rest)
+		   (processed ...) body ...)
+     (list-pattern final failure (second . rest)
+		   (processed ... first) body ...))
+
+    ((list-pattern (final ...) failure (last)
+		   (processed ...)
+		   body ...)
+     (final ... ((list processed ... last) body ...)
+            (_ failure)))
+
+    ((list-pattern (final ...) failure (last . tail)
+		   (processed ...) body ...)
+     (final ... ((list-rest processed ... last tail)
+		 body ...)
+            (_ failure)))
+    
+    ((list-pattern (final ...) failure improper
+		   () body ...)
+     (final ... (improper body ...) (_ failure)))))
+
+(define-syntax-rule (match-lambda-rest failure args
+				       processed body ...)
+  (list-pattern (match-lambda*) failure args
+		processed body ...))
+
+(define-syntax mlambda
+  (lambda (stx)
+    (syntax-case stx ()
+
+      ((_ args)
+       #'(match-lambda-rest #f args () #t))
+			    
+      ((_ (first-arg ... last-arg . rest-args) . body)
+       (and (every racket-argument?
+		   #'(first-arg ... last-arg))
+            (or (identifier? #'rest-args)
+                (empty? #'rest-args)))
+       #'(lambda (first-arg ... last-arg . rest-args) . body))
+      
+      ((_ arg body ...)
+       (or (identifier? #'arg) (empty? #'arg))
+       #'(lambda arg body ...))
+      
+      ((_ args body ...)
+       #'(match-lambda-rest
+	  (error "invalid pattern"
+		 '(lambda args body ...)) args () body ...))
+      )))
+
+(define-syntax cdefine
+  (syntax-rules ()
+    ((_ (prototype . args))
+     (cdefine-bodyless (prototype . args) #t))
+    
+    ((_ ((head . tail) . args) body ...)
+     (cdefine (head . tail) (mlambda args body ...)))
+
+    ((_ (function . args) body ...)
+     (define function
+       (procedure-rename
+	(mlambda args body ...)
+	'function)))
+    ((_ . rest)
+     (define . rest))
+    ))
+
+(define-syntax cdefine-bodyless
+  (syntax-rules ()
+   ((_ (function . pattern) result . args)
+    (cdefine-bodyless function
+		      (list-pattern
+		       (match arg)
+		       #f
+		       pattern
+		       ()
+		       result)
+		      arg . args))
+   
+   ((_ name result args ... arg)
+    (cdefine-bodyless name (lambda arg result) args ...))
+
+   ((_ name value)
+    (define name value))
+   ))
+
+(define-syntax-rule (match-let/error ((structure
+				       expression) ...)
+				     body + ...)
+  ((match-lambda-rest
+    (error "invalid pattern"
+	   '(let ((structure expression) ...) body + ...)
+	   `(expression ,expression) ...)
+    
+    (structure ...) () body + ...)
+   expression ...))
+
+(define-syntax named-match-let-values
+  (lambda (stx)
+    (syntax-case stx (values)
+      ((_ ((identifier expression) ...)
+          body + ...)
+       (every identifier? #'(identifier ...))
+       ;; optimization: plain "let" form
+       #'(let ((identifier expression) ...)
+           body + ...))
+      
+      ((_ name ((identifier expression) ...) 
+          body + ...)
+       (and (identifier? #'name)
+	    (every identifier? #'(identifier ...)))
+       ;; optimization: regular named-let
+       #'(let name ((identifier expression) ...)
+           body + ...))
+
+      ((_ name (((values . structure) expression))
+	  body + ...)
+       (identifier? #'name)
+       #'(letrec ((name (mlambda structure body + ...)))
+	   (call-with-values (lambda () expression) name)))
+
+      ((_ (((values . structure) expression)) body + ...)
+       #'(call-with-values (lambda () expression)
+	   (mlambda structure body + ...)))
+      
+      ((_ name ((structure expression) ...)
+          body + ...)
+       (identifier? #'name)
+       #'(letrec ((name (mlambda (structure ...)
+				 body + ...)))
+           (name expression ...)))
+      
+      ((_ ((structure expression) ...)
+          body + ...)
+       #'(match-let/error ((structure expression) ...) 
+                          body + ...))
+      
+      ((_ ((identifier identifiers ... expression))
+	  body + ...)
+       (every identifier? #'(identifier identifiers ...))
+       #'(call-with-values
+	     (lambda () expression)
+           (lambda (identifier identifiers ... . _)
+             body + ...)))
+      
+      ((_ ((structure structures ... expression))
+	  body + ...)
+       #'(call-with-values
+	     (lambda () expression)
+           (match-lambda-rest
+            (error "invalid pattern"
+		   '(let ((structure
+			   structures
+			   ...
+			   expression))
+		      body + ...))
+            (structure structures ... . _)
+            () body + ...)))
+      
+      ((_ name ((identifier identifiers ... expression))
+	  body + ...)
+       (and (identifier? #'name)
+            (every identifier? #'(identifier
+				  identifiers ...)))
+       #'(let ((name (lambda (identifier identifiers ...)
+		       body + ...)))
+           (call-with-values (lambda () expression) name)))
+      
+      ((_ name ((structure structures ... expression))
+	  body + ...)
+       (identifier? #'name)
+       #'(letrec ((name (match-lambda-rest
+			 (error "invalid pattern"
+				'(let name ((structure
+					     structures
+					     ...
+					     expression))
+				   body + ...))
+			 (structure structures ...)
+			 () body + ...)))
+           (call-with-values (lambda () expression) name)))
+
+      )))
+
+(define-syntax or/values
+  (syntax-rules ()
+    ((_)
+     #false)
+    
+    ((or/values final)
+     final)
+    
+    ((or/values first . rest)
+     (call-with-values
+	 (lambda () first)
+       (lambda result
+         (if (and (pair? result) (car result))
+             (apply values result)
+             (or/values . rest)))))))
+
+(define-syntax match-let*-values
+  (lambda (stx)
+    (syntax-case stx ()
+      ((_ ((identifier expression) ...) body + ...)
+       (every identifier? #'(identifier ...))
+       ;; optimization/base case: regular let*
+       #'(let* ((identifier expression) ...)
+	   body + ...))
+      ((_ (binding . bindings) body + ...)
+       #'(named-match-let-values (binding)
+				 (match-let*-values
+				  bindings
+				  body + ...))))))

--- a/srfi-201.html
+++ b/srfi-201.html
@@ -472,15 +472,17 @@ in the presence of a multiple-value binding"))
 
 <h2>Specific implementations</h2>
 
-<p>It is impossible to provide a portable implementation
-of this SRFI, because it relies on the ability of module
+<p>The implementation of this SRFI relies on the ability of module
   system to rename/shadow existing bindings.</p>
 
 <p>The repository of this SRFI contains one implementation
-  for Guile, and another for Racket. Each comes with
-  a test suite written in a literate programming style,
-  and either of those test suites is considered to be
-  an important supplement to this document.</p>
+  for <a href="https://github.com/panicz/srfi-201/tree/draft-2/guile/srfi/201.scm">Guile</a>,
+  and another for <a href="https://github.com/panicz/srfi-201/tree/draft-2/racket/srfi/201.rkt">Racket</a>.
+  Each comes with a test suite written in a literate programming style,
+  and either of those test suites - i.e. the one for
+  <a href="https://github.com/panicz/srfi-201/tree/draft-2/guile/examples.scm">Guile</a> and
+  the one for <a href="https://github.com/panicz/srfi-201/tree/draft-2/racket/examples.rkt">Racket</a>
+  - is an important supplement to this document.</p>
 
 <p>We encourage the maintainers of Scheme implementations
   that do not renaming/shadowing of core bindings, to

--- a/srfi-201.html
+++ b/srfi-201.html
@@ -525,7 +525,7 @@ in the presence of a multiple-value binding"))
   who persist in carrying the torch of Scheme development
   under the umbrella of the SRFI process, in particular
   to Arthur Gleckler for his patience, encouragement
-  and support, Marc Nieper Wisskirchen for his attentive
+  and support, Marc Nieper Wißkirchen for his attentive
   and insightful remarks, and John Cowan for shepherding
   the Scheme community.</p>
 

--- a/srfi-201.html
+++ b/srfi-201.html
@@ -26,10 +26,15 @@
   to the core bindings of the Scheme programming language.
   In particular, it proposes to extend the binding forms
   <code>lambda</code>, <code>let</code>,
-  <code>let*</code> with pattern matching capabilities, to extend the forms <code>let*</code>
+  <code>let*</code> with pattern matching capabilities, to extend the forms <code>let</code>,  <code>let*</code>
   and <code>or</code> with the ability
   to handle multiple values, and to extend the form <code>define</code> with
   the ability of defining "curried" functions.</p>
+
+<p>It also proposes a body-less variant of
+  the <code>lambda</code> form, and specifies the
+  behavior of body-less "curried" <code>define</code>
+  forms to behave consistently with that extension.</p>
 
 <h2>Issues</h2>
 
@@ -48,7 +53,8 @@ None at present.
   ability of Scheme procedures to return multiple values, which
   is a trait that wasn't supported conveniently in the core
   language and had to be accounted for in SRFI 8, SRFI 11 and
-  SRFI 71 (and remains forgotten by the <code>or</code> form).</p>
+  SRFI 71 (and remains forgotten by the <code>or</code> form).
+</p>
 
 <p>Various Scheme implementations provide the feature of
   "curried definitions", which allows one to generalize the
@@ -58,18 +64,19 @@ None at present.
   integrate well with the pattern-matching variant of
   the <code>lambda</code> form.</p>
 
-<p>The purpose of this document is to propose a set of extensions
-  to the core bindings that integrate well with both pattern matching
-  and multiple values. These extensions remain mostly backwards-compatible
-  with earlier usages of the core forms.</p>
-
+<p>The purpose of this document is to propose a set of
+  extensions to the core bindings that integrate well with
+  both pattern matching and multiple values. These extensions
+  remain mostly backwards-compatible with earlier usages
+  of the core forms.</p>
 
 <h2>Specification</h2>
 
 <h2>The pattern matching (destructuring) <code>lambda</code> form</h2>
 
-<p>This document assumes that the <code>lambda</code> form should allow
-  one to destructure its arguments, i.e. for example</p>
+<p>This document assumes that the <code>lambda</code> form
+  should allow one to destructure its arguments, i.e.
+  for example</p>
 
 <pre>
   (map (lambda (`(,x . ,y))
@@ -100,6 +107,30 @@ None at present.
       (_ (error "invalid args: "args", expected"'(&lt;patterns&gt; ...)))))
 </pre>
 
+<p>Moreover, in order to preserve backwards compatibility
+  and avoid unnecessary performance penalties, if each
+  <code>&lt;pattern&gt;</code> is an identifier,
+  then <code>lambda<sub>match</sub></code> desugars
+  directly into <code>lambda<sub>core</sub></code>.</p>
+
+<h2>Empty bodies in the <code>lambda</code> form</h2>
+
+<p>The ability to pattern-match arguments provides
+  a justification for <code>lambda</code> forms
+  with empty bodies: it makes sense to interpret</p>
+
+<pre>
+  (lambda<sub>match</sub> (&lt;patterns&gt; ...))
+</pre>
+
+as
+
+<pre>
+  (lambda<sub>core</sub> args
+    (match args
+      (`(,&lt;patterns&gt; ...) #t)
+      (_ #f)))
+</pre>
 
 <h2>The pattern-matching <code>let</code> form</h2>
 
@@ -112,12 +143,21 @@ None at present.
 
 <p>Moreover, if there is only one expression whose value is being bound using
   the <code>let</code> form, it should also be able to handle multiple values
-  (like SRFI 71, but with the ability to destructure additional values).</p>
+  (like SRFI 71, but with the ability to destructure the received values).</p>
 
 <p>To give an example, the form could be used in the following way:</p>
 
 <pre>
   (let lp ((`(,a ,b) `(,c) (values '(1 2) '(3))))
+    (+ a b c))
+</pre>
+
+<p>Following SRFI-71, we treat the <code>values</code>
+  keyword in the left position specially, so that the
+  above form is equivalent to</p>
+
+<pre>
+  (let lp (((values `(,a ,b) `(,c)) (values '(1 2) '(3))))
     (+ a b c))
 </pre>
 
@@ -176,6 +216,20 @@ into
 <p>This SRFI document requires that the <code>lambda</code> used in the desugared
   form supports destructuring.</p>
 
+<p>Moreover, since <code>lambda</code> forms with
+  empty bodies expand to predicates that say whether
+  given arguments satisfy the specified patterns
+  (rather than report an error), the behavior of
+  body-less "curried" definitions is made consistent
+  with the behavior of body-less <code>lambda</code>
+  forms: all levels of arguments are tested against
+  the specified pattetns, and if some arguments do not
+  comply with the requested patterns, the final procedure
+  evaluates to <code>#f</code>; otherwise, i.e. if all
+  arguments conform to their corresponding patterns,
+  the final procedure evaluates to <code>#t</code>.
+</p>
+
 <h2>The <code>or</code> form that supports multiple values</h2>
 
 <p>The <code>or</code> binding provided by default in the Scheme language exposes
@@ -210,6 +264,12 @@ the SRFI 1 <code>every</code> procedure available during macro expansion.</p>
   (lambda (stx)
     (syntax-case stx ()
 
+      ((_ args)
+       #'(lambda args*
+	   (match args*
+	     (args #t)
+	     (_ #f))))
+
       ((_ (first-arg ... last-arg . rest-args) . body)
        (and (every identifier? #'(first-arg ... last-arg))
 	    (or (identifier? #'rest-args) (null? #'rest-args)))
@@ -238,6 +298,9 @@ the SRFI 1 <code>every</code> procedure available during macro expansion.</p>
 <pre>
 (define-syntax cdefine
   (syntax-rules ()
+    ((_ (prototype . args))
+     ;; the body-less variant: see below
+     (cdefine-bodyless (prototype . args) #t))
     ((_ ((head . tail) . args) body ...)
      (cdefine (head . tail)
 	      (mlambda args body ...)))
@@ -247,6 +310,22 @@ the SRFI 1 <code>every</code> procedure available during macro expansion.</p>
     ((_ . rest)
      (define . rest))
     ))
+
+(define-syntax cdefine-bodyless
+  (syntax-rules ()
+   ((_ (function . pattern) result . args)
+    (cdefine-bodyless function
+		      (match arg
+			(pattern result)
+			(_ #f))
+		      arg . args))
+   
+   ((_ name result args ... arg)
+    (cdefine-bodyless name (lambda arg result) args ...))
+
+   ((_ name value)
+    (define name value))
+   ))
 </pre>
 
 <h2>Pattern-matching variant of the <code>let</code> form that supports multiple values</h2>
@@ -261,28 +340,53 @@ the SRFI 1 <code>every</code> procedure available during macro expansion.</p>
     ((_ ((structure expression) ...)
 	body + ...)
      ((lambda args
-        (match args
-         ((structure ...) body + ...)
-	 (_ (error 'match-let/error
-		   '((structure expression) ...)
-		   expression ...))))
-       expression ...))))
+	(match args
+	  ((structure ...) body + ...)
+	  (_ (error 'match-let/error
+		    (current-source-location) 
+		    '((structure expression) ...)
+		    expression ...))))
+      expression ...))))
 
 (define-syntax named-match-let-values
   (lambda (stx)
-    (syntax-case stx ()
-      ((_ ((identifier expression) ...) ;; optimization: plain "let" form
+    (syntax-case stx (values)
+      ((_ ((identifier expression) ...) 
 	  body + ...)
        (every identifier? #'(identifier ...))
+       ;; optimization: plain "let" form
        #'(let ((identifier expression) ...)
 	   body + ...))
 
-      ((_ name ((identifier expression) ...) ;; optimization: regular named-let
+      ((_ name ((identifier expression) ...) 
 	  body + ...)
-       (and (identifier? #'name) (every identifier? #'(identifier ...)))
+       (and (identifier? #'name)
+	    (every identifier? #'(identifier ...)))
+       ;; optimization: regular named-let
        #'(let name ((identifier expression) ...)
 	   body + ...))
 
+      ((_ name (((values . structure) expression))
+	  body + ...)
+       (identifier? #'name)
+       #'(letrec ((name (mlambda structure body + ...)))
+	   (call-with-values (lambda () expression) name)))
+
+      ((_ (((values . structure) expression)) body + ...)
+       #'(call-with-values (lambda () expression)
+	   (mlambda structure body + ...)))
+
+      ((_ name ((structure expression) ...)
+	  body + ...)
+       (and (identifier? #'name)
+	    (any (lambda (pattern)
+		   (display pattern)(newline)
+		   (and (pair? pattern)
+			(eq? (car pattern) 'values)))
+		 (syntax->datum #'(structure ...))))
+       #'(syntax-error "let can only handle one binding \
+in the presence of a multiple-value binding"))
+      
       ((_ name ((structure expression) ...)
 	  body + ...)
        (identifier? #'name)
@@ -291,36 +395,30 @@ the SRFI 1 <code>every</code> procedure available during macro expansion.</p>
 
       ((_ ((structure expression) ...)
 	  body + ...)
-       #'(match-let/error ((structure expression) ...)
+       (any (lambda (pattern)
+	      (and (pair? pattern)
+		   (eq? (car pattern) 'values)))
+	    (syntax->datum #'(structure ...)))
+       #'(syntax-error "let can only handle one binding \
+in the presence of a multiple-value binding"))
+      
+      ((_ ((structure expression) ...)
+	  body + ...)
+       #'(match-let/error ((structure expression) ...) 
 			  body + ...))
-
-      ((_ ((identifier identifiers ... expression)) body + ...)
-       (every identifier? #'(identifier identifiers ...))
-       #'(call-with-values (lambda () expression)
-	   (lambda (identifier identifiers ... . _)
-	     body + ...)))
 
       ((_ ((structure structures ... expression)) body + ...)
        #'(call-with-values (lambda () expression)
-          (lambda args
-            (match args
-             ((structure structures ... . _) body + ...)
-	     (_ (error 'named-match-let-values  'name))))))
+	   (mlambda (structure structures ... . _)
+		    body + ...)))
 
-      ((_ name ((identifier identifiers ... expression) body + ...))
-       (and (identifier? #'name)
-	    (every identifier? #'(identifier identifiers ...)))
-       #'(let ((name (lambda (identifier identifiers ...) body + ...)))
-	   (call-with-values (lambda () expression) name)))
-
-      ((_ name ((structure structures ... expression) body + ...))
+      ((_ name ((structure structures ... expression))
+		body + ...)
        (identifier? #'name)
-       #'(let ((name (lambda args
-                       (match args
-                         ((structure structures ...) body + ...)
-                         (_ (error 'named-match-let-values 'name))))))
+       #'(letrec ((name (mlambda (structure structures ...)
+			     body + ...)))
 	   (call-with-values (lambda () expression) name)))
-      )))
+    )))
 </pre>
 
 
@@ -329,49 +427,24 @@ the SRFI 1 <code>every</code> procedure available during macro expansion.</p>
 <p>The pattern-matching variant of the <code>let*</code> form
   can be implemented by defining the following <code>match-let*-values</code>
   form and exporting it to shadow the core <code>let*</code> form. It assumes the
-  presence of the definition of the <code>match-let/error</code> form from
+  presence of the definition of the <code>named-match-let-values</code> form from
   the previous section</p>
 
 <pre>
 (define-syntax match-let*-values
   (lambda (stx)
     (syntax-case stx ()
-
-      ((_ ((identifier expression) ...) ;; optimization: regular let*
-	  body + ...)
+      ((_ ((identifier expression) ...) body + ...)
        (every identifier? #'(identifier ...))
+       ;; optimization/base case: regular let*
        #'(let* ((identifier expression) ...)
 	   body + ...))
+      ((_ (binding . bindings) body + ...)
+       #'(named-match-let-values (binding)
+				 (match-let*-values
+				  bindings
+				  body + ...))))))
 
-      ((_ ((identifier expression) remaining-bindings ...)
-	  body + ...)
-       (identifier? #'identifier)
-       #'(let ((identifier expression))
-	   (match-let*-values (remaining-bindings ...) body + ...)))
-
-      ((_ ((structure expression) remaining-bindings ...)
-	  body + ...)
-       #'(match-let/error ((structure expression))
-			  (match-let*-values (remaining-bindings ...)
-					     body + ...)))
-
-      ((_ ((identifier identifiers ... expression) remaining-bindings ...)
-	  body + ...)
-       (every identifier? #'(identifier identifiers ...))
-       #'(call-with-values (lambda () expression)
-	   (lambda (identifier identifiers ... . _)
-	     (match-let*-values (remaining-bindings ...)
-				body + ...))))
-
-      ((_ ((structure structures ... expression) remaining-bindings ...)
-	  body + ...)
-       #'(call-with-values (lambda () expression)
-           (lambda args
-             (match args
-               ((structure structures ... . _)
-		(match-let*-values (remaining-bindings ...) body + ...))
-	        (_ (error 'match-let*-values))))))
-      )))
 </pre>
 
 <h2>A variant of the <code>or</code> form that supports multiple values</h2>
@@ -397,18 +470,62 @@ the SRFI 1 <code>every</code> procedure available during macro expansion.</p>
 	     (or/values . rest)))))))
 </pre>
 
-<h2>Real-life implementations</h2>
+<h2>Specific implementations</h2>
 
-<p>A working implementation of a superset of these definitions for Guile Scheme can be found
-  in the <a href="https://github.com/plande/grand-scheme/blob/master/grand/syntax.scm">(grand syntax)</a>
-  module of the <a href="https://github.com/plande/grand-scheme">(grand scheme)</a> glossary.</p>
+<p>It is impossible to provide a portable implementation
+of this SRFI, because it relies on the ability of module
+  system to rename/shadow existing bindings.</p>
 
-<p>A working implementation of a superset of these definitions for the Racket
-  language can be found in the <a href="https://github.com/panicz/sracket/blob/master/grand-syntax.rkt">"grand-syntax.rkt"</a> module of the <a href="https://github.com/panicz/sracket">Sracket</a> framework.</p>
+<p>The repository of this SRFI contains one implementation
+  for Guile, and another for Racket. Each comes with
+  a test suite written in a literate programming style,
+  and either of those test suites is considered to be
+  an important supplement to this document.</p>
 
+<p>We encourage the maintainers of Scheme implementations
+  that do not renaming/shadowing of core bindings, to
+  extend their core bindings with the capabilities described
+  in this document.</p>
+  
 <h2>Acknowledgements</h2>
 
-??? credit where it is due
+<p>First of all, I'd like to thank Ścisław Dercz for being
+  an early adopter of the <code><a href="https://github.com/plande/grand-scheme">(grand scheme) glossary</a></code>,
+  which has been the base for the set of extensions proposed
+  in this document.
+  I am particularly proud of the fact that Dercz chose
+  (grand scheme) to write a set of his programming doodles
+  that he called <a href="https://github.com/drcz/useless-software">Useless Software</a>.
+</p>
+
+<p>I'm also very grateful to the developers of Guile,
+  who - through their <code>(ice-9 curried-definitions)</code>
+  module - taught me, that overriding core Scheme forms is not
+  only conceivable, but can also be very useful.</p>
+
+<p>I consider this work to be a part of decades-long
+  evolution in functional programming style, dating back
+  at least to Robin Milner and Rod Burstall, who pioneered
+  pattern matching in programming languages.</p>
+
+<p>This work has originally been based on pattetn matcher
+  written by Alex Shinn, based on the specification
+  presented by Andrew K. Wright and Robert Cartwright,
+  and the Guile implementation of this SRFI still uses
+  Shinn's <code>match</code> as its base.</p>
+
+<p>The Racket version of this SRFI owes its existence
+  to the kindness of the Racket community, and in particular
+  to Jesse Alama, who invited me to speak at Racketfest
+  that he organized in Berlin in 2019.</p>
+
+<p>Last but not least, I'd like to thank all the people
+  who persist in carrying the torch of Scheme development
+  under the umbrella of the SRFI process, in particular
+  to Arthur Gleckler for his patience, encouragement
+  and support, Marc Nieper Wisskirchen for his attentive
+  and insightful remarks, and John Cowan for shepherding
+  the Scheme community.</p>
 
 <h2>Copyright</h2>
 Copyright &copy; Panicz Maciej Godek (2020).


### PR DESCRIPTION
Hello, Arthur!

I managed to extract reference implementations for Guile and Racket, and to develop test suites for both implementations (my own unit test frameworks are included, because the two test frameworks described in SRFIs weren't suitable for my needs)

I have also described some new features in this draft:
- the `let` and `let*` now treat the `values` keyword in the binding's left position specially (like SRFI-71), following Marc's suggestion (even though gave it in the context of SRFI-202)
- the `lambda` and `define` keywords now have "body-less" variants, which effectively make them to define predicates that return `#t` if the arguments match a specified pattern

The text contains links to reference implementations in my fork of the repo - I guess you'll need to fix them to point upstream.

Let me know if everything's OK, and I'll move on to SRFI-202.

Thanks!